### PR TITLE
fix: запись в СЖ при подслушивании в винном погребе ГПК

### DIFF
--- a/PROGRAM/quests/reaction_functions.c
+++ b/PROGRAM/quests/reaction_functions.c
@@ -4582,13 +4582,17 @@ void LCS_EndScriptInterception()
 	pchar.quest.LCS_EndScriptInterception_2.win_condition.l1.location = pchar.location;
 	pchar.quest.LCS_EndScriptInterception_2.function = "LCS_EndScriptInterception_2";
 	if (pchar.questTemp.LSC == "InterceptionOk")
+	{
 		AddQuestRecord("ISS_MainLine", "22");
 		AddQuestUserData("ISS_MainLine", "sSex", GetSexPhrase("как полный кретин","как полная дура"));
 		AddQuestUserData("ISS_MainLine", "sSex1", GetSexPhrase("","а"));
+	}
 	else
+	{
 		AddQuestRecord("ISS_MainLine", "20");
 		AddQuestUserData("ISS_MainLine", "sSex", GetSexPhrase("ся","ась"));
 		AddQuestUserData("ISS_MainLine", "sSex1", GetSexPhrase("","а"));
+	}
 
 }
 


### PR DESCRIPTION
Из-за ошибки в синтаксисе игра неправильно считывала флаги и могла добавить не ту запись