### PR TITLE
fix: Мушкетёры во время абордажа

### DIFF
--- a/PROGRAM/Loc_ai/LAi_boarding.c
+++ b/PROGRAM/Loc_ai/LAi_boarding.c
@@ -1235,7 +1235,7 @@ string LAi_GetBoardingMushketerModel(ref rCharacter)
 	
 	if (iNation < 0) iNation = PIRATE;
 	//eddy. замаскировавшися пиратов тоже надо учитывать
-	if (CheckAttribute(rCharacter, "Ship.Mode") && rCharacter.Ship.Mode == "Pirate") iNation = PIRATE;
+	if (CheckAttribute(rCharacter, "Ship.Mode") && rCharacter.Ship.Mode == "Pirate" && !IsMainCharacter(rCharacter)) iNation = PIRATE;
 	if(iNation == PIRATE)
 	{
 		model = "mushketer_" + (rand(4)+1);


### PR DESCRIPTION
Матросы команды ГГ спаунились в зависимости от нации, а мушкетёры могли появиться в виде пиратов из-за недочёта в if'е. Я добавил аргумент, который имеется в полностью аналогичной строчке для выбора моделек матросов.