### PR TITLE
fix: (Квест Арнольда) Положение NPC

### DIFF
--- a/PROGRAM/dialogs/russian/Quest/Ascold.c
+++ b/PROGRAM/dialogs/russian/Quest/Ascold.c
@@ -820,6 +820,8 @@ void ProcessDialogEvent()
     		link.l1.go = "exit";
             NextDiag.TempNode = "GoodFriends";
             pchar.questTemp.Ascold = "Ascold_OverBusiness";
+		ChangeCharacterAddressGroup(&characters[GetCharacterIndex("Ascold")], "BasTer_houseSp1", "sit", "sit1"); //Обратно сажаем
+		LAi_SetSitType(&characters[GetCharacterIndex("Ascold")]);
 		break;
 
  		case "GoodFriends":


### PR DESCRIPTION
После штурма Аскольд стоит, а не сидит. И если при обсуждении штурма это ещё имеет смысл (он только вышел со второго этажа, убрав свои баррикады), то по окончанию квеста пусть садится обратно за стол.