### PR TITLE
fix: (Убить всех нищих) Альтернативное прохождение

### DIFF
--- a/PROGRAM/dialogs/russian/Rumours/Common_rumours.c
+++ b/PROGRAM/dialogs/russian/Rumours/Common_rumours.c
@@ -991,6 +991,9 @@ void ProcessCommonDialogRumors(ref NPChar, aref Link, aref NextDiag);
 			link.l1 = "Я понял"+ GetSexPhrase("","а") +" вас, спасибо. Я подумаю.";
 			link.l1.go = "exit";
 			pchar.questTemp.LSC = "over"; //конец линейки ГПК
+			sld = characterFromId("hol_guber"); //чтобы Стэвезан мог переезжать, когда снимется пауза
+			DeleteAttribute(sld, "notMoveAble");
+			DeleteAttribute(&colonies[FindColony("Villemstad")], "notCaptured"); //Виллемстад можно себе
 			CloseQuestHeader("ISS_PoorsMurder");
 		break;
 		//механика арестовали, диалоги мужика


### PR DESCRIPTION
Есть альтернативное прохождение, где ГГ буквально убивает всех нищих. Надо и в этом случае открывать возможность захватывать Виллемстад себе после получения миллиона, а также разрешить генерал-губернатору менять города. Эти вещи я взял из скрипта попадания в ГПК.

Изначально ограничения стоят как раз, чтобы игрок мог выполнить квест.