### PR TITLE
fix: Оливер Грин определяет, где Морган

### DIFF
--- a/PROGRAM/dialogs/russian/Quest/OliverGreen.c
+++ b/PROGRAM/dialogs/russian/Quest/OliverGreen.c
@@ -16,7 +16,7 @@ void ProcessDialogEvent()
 	{
 		// ----------------------------------- Диалог первый - первая встреча
 		case "First time":
-            if (sld.location == pchar.location && bWorldAlivePause)
+            if (sld.location == pchar.location)
             {
     			dialog.text = "Если ты к адмиралу, то пройди чуть дальше. Он сейчас в резиденции.";
     			link.l1 = "Хорошо, пойду поговорю с ним.";


### PR DESCRIPTION
Проверка на паузу мира ломает ответы. Были протестированы всевозможные ситуации (линейки, уезд в Лондон, возвращение оттуда) и без неё всё работает прекрасно. Если проверка на паузу мира стоит, то он будет врать, что Моргана дома нет, когда тот сидит перед носом ГГ.