### PR TITLE
fix: Модельки мушкетёров при штурме

### DIFF
--- a/PROGRAM/scripts/colony.c
+++ b/PROGRAM/scripts/colony.c
@@ -732,13 +732,13 @@ void TWN_FightInTown()
 					for (i = 0; i < MAX_TOWN_MUSHKETER; i++)
 					{				
 						if (sti(Pchar.GenQuestFort.PlayerCrew) < 1) break;
-						if(sti(pchar.nation) == PIRATE)
+						if (sti(Items[sti(pchar.EquipedPatentId)].TitulCur) > 1) //форма только со звания капитан
 						{
-							sModel = "mushketer_" + (rand(4)+1);
+							sModel = NationShortName(sti(pchar.nation)) + "_mush_" + i;
 						}
 						else
 						{
-							sModel = NationShortName(sti(pchar.nation)) + "_mush_" + i;
+							sModel = "mushketer_" + (rand(4)+1);
 						}				
 						sld = GetCharacter(NPC_GenerateCharacter("GenChar_", sModel, "man", "mushketer", 5, sti(pchar.nation), 0, false));
 						sld.id = "GenChar_" + sld.index;


### PR DESCRIPTION
Если захватывать город с совпадающим флагом, то у ГГ он автоматически меняется на пиратский, и мушкетёры спаунятся пиратские. Но вот если нападать без патента и звания на город другой нации, то мушкетёры заспаунятся в виде офицеров нации, будто у игрока есть патент. Флаг в этом случае не меняется на пиратский, и их модельки выбираются по нации без проверки патента.

Теперь мушкетёры выбираются по тому же принципу, что и солдаты. Я потестил в разных ситуациях, исключений нет.