### PR TITLE
fix: Несуществующий грит бармена Сан-Хуана

### DIFF
--- a/PROGRAM/characters/init/PuertoRico.c
+++ b/PROGRAM/characters/init/PuertoRico.c
@@ -68,7 +68,7 @@ int CreatePuertoRicoCharacters(int n)
 	makeref(ch,Characters[n]);			//Трактирщик
 	ch.id = "SanJuan_tavernkeeper";
 	ch.model	= "barmen_12";
-	ch.greeting = "Barmen_4";
+	ch.greeting = "Gr_Barmen";
 	ch.sex = "man";
 	ch.City = "SanJuan";
 	ch.location	= "SanJuan_Tavern";


### PR DESCRIPTION
Прописал "Gr_Barmen", т.к. "Barmen_4" не работает и был там по ошибке.