### PR TITLE
fix: группа грузчиков в городах ГГ

### DIFF
--- a/PROGRAM/Loc_ai/LAi_utilites.c
+++ b/PROGRAM/Loc_ai/LAi_utilites.c
@@ -437,7 +437,14 @@ void CreateCitizens(aref loc)
 			}
 			ChangeCharacterAddressGroup(chr, loc.id, "reload", "gate");
 			LAi_SetCarrierType(chr);
-			LAi_group_MoveCharacter(chr, slai_group);
+			if (sti(Colonies[iColony].HeroOwn) == true)
+			{
+				LAi_group_MoveCharacter(chr, LAI_GROUP_PLAYER_OWN);
+			}
+			else
+			{
+				LAi_group_MoveCharacter(chr, slai_group);
+			}
 		}
 	}
 	// грузчики <--


### PR DESCRIPTION
Грузчики должны быть в одной группе со стражей. Иначе, если ГГ ударит их в своём городе, то вся стража начнёт нападать на грузчиков. А так как они ещё и деспаунятся, когда доходят до точки назначения, то солдаты (стража) ведут себя максимально багованно.