### PR TITLE
fix: [Работорговец, 4 задание] Отсутствие закрытия дверей

### DIFF
--- a/PROGRAM/dialogs/russian/Quest/Other_Quests_NPC.c
+++ b/PROGRAM/dialogs/russian/Quest/Other_Quests_NPC.c
@@ -225,6 +225,7 @@ void ProcessDialogEvent()
 			LAi_SetWarriorTypeNoGroup(npchar);
             LAi_group_SetRelation("EnemyFight", LAI_GROUP_PLAYER, LAI_GROUP_ENEMY);
             LAi_group_FightGroups("EnemyFight", LAI_GROUP_PLAYER, false);
+			chrDisableReloadToLocation = true;
             LAi_group_SetCheck("EnemyFight", "OpenTheDoors");
             DialogExit();
 			AddDialogExitQuest("MainHeroFightModeOn");


### PR DESCRIPTION
Функция на открытие после убийства группы есть, а на закрытие нет.