### PR TITLE
fix: AI на море у квестовых капитанов

### DIFF
--- a/PROGRAM/sea_ai/AIShip.c
+++ b/PROGRAM/sea_ai/AIShip.c
@@ -1206,6 +1206,9 @@ void Ship_CheckSituation()
 		}
 		if (GetNationRelation2MainCharacter(sti(rCharacter.nation)) == RELATION_ENEMY) // враг Гл героя
 	    {
+		// 08.10.23 Rosarak. fix на случай, если есть проблема от неудалённого SinkTenPercent или другой пакости
+		if(rCharacter.relation.1 != RELATION_ENEMY && !CheckAttribute(rCharacter, "AlwaysFriend")) SetCharacterRelationBoth(sti(rCharacter.index), GetMainCharacterIndex(), RELATION_ENEMY);
+
             if (CheckAttribute(rCharacter, "AlwaysFriend"))
 	        {
 	            SetCharacterRelationBoth(sti(rCharacter.index), GetMainCharacterIndex(), RELATION_FRIEND);


### PR DESCRIPTION
В основном проблема из-за SinkTenPercent, но это поможет и в общем случае. Палёный атрибут нужно отлавливать отдельно.